### PR TITLE
Change connection failure message

### DIFF
--- a/vendor/src/github.com/docker/engine-api/client/errors.go
+++ b/vendor/src/github.com/docker/engine-api/client/errors.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ErrConnectionFailed is a error raised when the connection between the client and the server failed.
-var ErrConnectionFailed = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
+var ErrConnectionFailed = errors.New("Cannot connect to the server")
 
 // imageNotFoundError implements an error returned when an image is not in the docker host.
 type imageNotFoundError struct {

--- a/vendor/src/github.com/docker/engine-api/client/hijack.go
+++ b/vendor/src/github.com/docker/engine-api/client/hijack.go
@@ -53,7 +53,7 @@ func (cli *Client) postHijacked(path string, query url.Values, body interface{},
 	conn, err := dial(cli.proto, cli.addr, cli.tlsConfig)
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
-			return types.HijackedResponse{}, fmt.Errorf("Cannot connect to the Docker daemon. Is 'docker daemon' running on this host?")
+			return types.HijackedResponse{}, ErrConnectionFailed
 		}
 		return types.HijackedResponse{}, err
 	}


### PR DESCRIPTION
We are not really connecting to a Docker daemon now.
Also don't handcraft error code in postHijacked. Use the
predefined one.

Signed-off-by: Peng Tao <bergwolf@gmail.com>