### PR TITLE
Init protocol based volume mapping in hyper run

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -166,8 +167,8 @@ func (cli *DockerCli) initSpecialVolumes(config *container.Config, hostConfig *c
 		case "git":
 			cmd = append(cmd, "git", "clone", vol.Source, INIT_VOLUME_PATH+vol.Destination)
 		case "http":
-			// TODO
-			// cmd = append(cmd, "wget", "--no-check-certificate", "--tries=5", "--mirror", vol.Source, "--directory-prefix="+INIT_VOLUME_PATH+vol.Destination)
+			parts := strings.Split(vol.Source, "/")
+			cmd = append(cmd, "wget", "--no-check-certificate", "--tries=5", "--mirror", "--no-host-directories", "--cut-dirs="+strconv.Itoa(len(parts)), vol.Source, "--directory-prefix="+INIT_VOLUME_PATH+vol.Destination)
 		case "local":
 			// TODO
 		default:


### PR DESCRIPTION
This PR adds support protocol (git, http and https) based volume mapping to `hyper run` command. For each protocol based volume, a new volume is created and filled in with contents pointed by the protocol URL.

http://
```
[lear@getdvm]$pkt run -d -v https://github.com/nginxinc/docker-nginx/raw/master/stable/alpine/Dockerfile:/data busybox
3326018a72d759141aa51136c5273260a4b4fef53107d66615128ef6af505165
[lear@getdvm]$pkt exec 3326018a72d759141aa51136c5273260a4b4fef53107d66615128ef6af505165 df
Filesystem           1K-blocks      Used Available Use% Mounted on
/dev/sdb              10190100     38080   9611348   0% /
devtmpfs                250552         0    250552   0% /dev
tmpfs                   253344         0    253344   0% /dev/shm
/dev/sda              10190100     36900   9612528   0% /data
share_dir                 1024         4      1020   0% /etc/hosts
[lear@getdvm]$pkt exec 3326018a72d759141aa51136c5273260a4b4fef53107d66615128ef6af505165 ls /data
Dockerfile
```

git over http:
```
[lear@getdvm]$pkt run -d -v https://github.com/nginxinc/docker-nginx.git:/data busybox
79ca01052ca2b00c756d0fd49eee4a3110b6d30f88d07b08304bf53a0e0be359
[lear@getdvm]$pkt exec -t 79ca01052ca2b00c756d0fd49eee4a3110b6d30f88d07b08304bf53a0e0be359 ls /data
README.md  mainline   stable
[lear@getdvm]$pkt exec 79ca01052ca2b00c756d0fd49eee4a3110b6d30f88d07b08304bf53a0e0be359 df
Filesystem           1K-blocks      Used Available Use% Mounted on
/dev/sda              10190100     38080   9611348   0% /
devtmpfs                250552         0    250552   0% /dev
tmpfs                   253344         0    253344   0% /dev/shm
/dev/sdb              10190100     37168   9612260   0% /data
share_dir                 1024         4      1020   0% /etc/hosts
```

git://
```
[lear@getdvm]$pkt run -d -v git://git.kernel.org/pub/scm/devel/pahole/pahole.git:/data busybox
510986f6721ae039e4bd819d86facd5dd302e523a3e8992431cae6616f81bc75
[lear@getdvm]$pkt exec -t 510986f6721ae039e4bd819d86facd5dd302e523a3e8992431cae6616f81bc75 ls
bin   data  dev   etc   home  lib   proc  root  sys   tmp   usr   var
[lear@getdvm]$pkt exec 510986f6721ae039e4bd819d86facd5dd302e523a3e8992431cae6616f81bc75 df
Filesystem           1K-blocks      Used Available Use% Mounted on
/dev/sdb              10190100     38080   9611348   0% /
devtmpfs                250552         0    250552   0% /dev
tmpfs                   253344         0    253344   0% /dev/shm
/dev/sda              10190100     39152   9610276   0% /data
share_dir                 1024         4      1020   0% /etc/hosts
```