### PR TITLE
Restart reload support

### DIFF
--- a/api/client/restart.go
+++ b/api/client/restart.go
@@ -8,19 +8,48 @@ import (
 	flag "github.com/hyperhq/hypercli/pkg/mflag"
 )
 
+func (cli *DockerCli) restartReloadContainer(name string, seconds int) error {
+	// stop container
+	err := cli.client.ContainerStop(name, seconds)
+	if err != nil {
+		return err
+	}
+	// reload all sourced volumes of a container
+	initvols, err := cli.containerFilterInitVolumes(name)
+	if err != nil {
+		return err
+	}
+	if len(initvols) > 0 {
+		err = cli.containerReloadInitVolumes(initvols)
+		if err != nil {
+			return err
+		}
+	}
+	// start container
+	return cli.client.ContainerStart(name)
+}
+
 // CmdRestart restarts one or more containers.
 //
 // Usage: docker restart [OPTIONS] CONTAINER [CONTAINER...]
 func (cli *DockerCli) CmdRestart(args ...string) error {
 	cmd := Cli.Subcmd("restart", []string{"CONTAINER [CONTAINER...]"}, Cli.DockerCommands["restart"].Description, true)
 	nSeconds := cmd.Int([]string{"t", "-time"}, 10, "Seconds to wait for stop before killing the container")
+	reload := cmd.Bool([]string{"r", "-reload"}, false, "Reload container's volumes that have a source")
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)
 
+	if *reload {
+		addTrustedFlags(cmd, true)
+	}
 	var errs []string
 	for _, name := range cmd.Args() {
-		if err := cli.client.ContainerRestart(name, *nSeconds); err != nil {
+		restartFunc := cli.client.ContainerRestart
+		if *reload {
+			restartFunc = cli.restartReloadContainer
+		}
+		if err := restartFunc(name, *nSeconds); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -177,7 +177,12 @@ func (cli *DockerCli) initSpecialVolumes(config *container.Config, hostConfig *c
 		volType := checkSourceType(vol.Source)
 		switch volType {
 		case "git":
-			cmd = append(cmd, "git", "clone", vol.Source, INIT_VOLUME_PATH+vol.Destination)
+			// Only need to clone for the very first time volume gets initialized
+			if config.Image != "" {
+				cmd = append(cmd, "git", "clone", vol.Source, INIT_VOLUME_PATH+vol.Destination)
+			} else {
+				cmd = append(cmd, "sh", "-c", "cd "+INIT_VOLUME_PATH+vol.Destination+" && git pull")
+			}
 		case "http":
 			parts := strings.Split(vol.Source, "/")
 			cmd = append(cmd, "wget", "--no-check-certificate", "--tries=5", "--mirror", "--no-host-directories", "--cut-dirs="+strconv.Itoa(len(parts)), vol.Source, "--directory-prefix="+INIT_VOLUME_PATH+vol.Destination)

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -156,7 +156,7 @@ func (cli *DockerCli) initSpecialVolumes(config *container.Config, hostConfig *c
 	}
 	defer func() {
 		if err != nil {
-			if _, rmErr := cli.removeContainer(createResponse.ID, true, false, true); rmErr != nil {
+			if _, rmErr := cli.removeContainer(createResponse.ID, false, false, true); rmErr != nil {
 				fmt.Fprintf(cli.err, "clean up init container failed: %s\n", rmErr.Error())
 			}
 		}
@@ -365,6 +365,9 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 	if len(initvols) > 0 {
 		err := cli.initSpecialVolumes(config, hostConfig, networkingConfig, initvols)
 		if err != nil {
+			for _, vol := range initvols {
+				cli.client.VolumeRemove(vol.Name)
+			}
 			cmd.ReportError(err.Error(), true)
 			return runStartContainerErr(err)
 		}

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -131,6 +131,9 @@ func (cli *DockerCli) initSpecialVolumes(config *container.Config, hostConfig *c
 		User:       config.User,
 		Image:      INIT_VOLUME_IMAGE,
 		StopSignal: config.StopSignal,
+		Labels: map[string]string{
+			"reload": "yes",
+		},
 	}
 
 	initHostConfig = &container.HostConfig{

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -16,6 +16,8 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/container"
+	networktypes "github.com/docker/engine-api/types/network"
 	registrytypes "github.com/docker/engine-api/types/registry"
 	"github.com/dutchcoders/goftp"
 	"github.com/hyperhq/hypercli/pkg/signal"
@@ -241,6 +243,70 @@ func (cli *DockerCli) uploadLocalResource(source, dest, serverIP, user, passwd s
 	}
 
 	if err = ftp.Upload(source); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cli *DockerCli) containerFilterInitVolumes(containerID string) ([]*InitVolume, error) {
+	_, raw, err := cli.client.ContainerInspectWithRaw(containerID, false)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to inspect container: %s", err.Error())
+	}
+
+	var contMap map[string]*json.RawMessage
+	err = json.Unmarshal(raw, &contMap)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal inspect result: %s", err.Error())
+	}
+
+	var hostMap map[string]*json.RawMessage
+	err = json.Unmarshal(*contMap["HostConfig"], &hostMap)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal inspected result: %s", err.Error())
+	}
+
+	binds := make([]string, 0)
+	err = json.Unmarshal(*hostMap["Binds"], &binds)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal binding result: %s", err.Error())
+	}
+
+	var initvols []*InitVolume
+	for _, bind := range binds {
+		part := strings.Split(bind, ":")
+		count := len(part)
+		if count != 2 {
+			continue
+		}
+		vol, err := cli.client.VolumeInspect(part[0])
+		if err != nil {
+			return nil, err
+		}
+		source, ok := vol.Labels["source"]
+		if ok {
+			initvols = append(initvols, &InitVolume{
+				Source:      source,
+				Destination: part[1],
+				Name:        vol.Name,
+			})
+		}
+	}
+
+	return initvols, nil
+}
+
+func (cli *DockerCli) containerReloadInitVolumes(initvols []*InitVolume) error {
+	var (
+		config           container.Config
+		hostConfig       container.HostConfig
+		networkingConfig networktypes.NetworkingConfig
+	)
+
+	config.StopSignal = "SIGTERM"
+	err := cli.initSpecialVolumes(&config, &hostConfig, &networkingConfig, initvols)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR adds support to `hyper restart --reload` command that restarts a container and reloads all of its volumes that have a source.

It is based on top of https://github.com/hyperhq/hypercli/pull/122 and needs the same server side change to work.

```
[lear@getdvm]$mypkt start --reload 186b855896c9a96fbd69ca91930e9155c4619caaa3440311ac3380faabcb4d3b
186b855896c9a96fbd69ca91930e9155c4619caaa3440311ac3380faabcb4d3b
[lear@getdvm]$
```
