### PR TITLE
Init file based volume with special file name

### DIFF
--- a/api/client/exec.go
+++ b/api/client/exec.go
@@ -198,7 +198,7 @@ func (cli *DockerCli) WaitExec(execID string) error {
 		case running:
 			time.Sleep(100 * time.Millisecond)
 		case status != 0:
-			err = fmt.Errorf("Failed to init volume: %d", status)
+			err = fmt.Errorf("Failed to exec cmd: %d", status)
 			return err
 		case status == 0:
 			return nil


### PR DESCRIPTION
So that server can use the same file name to identify a file based volume, and mount it to a file in container instead of mounting its parent directory.

Needs https://github.com/hyperhq/hyperstart/pull/120

```
[lear@hyperstart]$mypkt run -d -v https://github.com/nginxinc/docker-nginx/raw/master/stable/alpine/Dockerfile:/data1 -v https://github.com/nginxinc/docker-nginx.git:/data2 busybox
6d6fb4dfc9bf38230424b7876d1f716169acc5551308783a20a0816261d8fa3c
[lear@hyperstart]$mypkt exec 6d6fb4dfc9bf38230424b7876d1f716169acc5551308783a20a0816261d8fa3c ls -la /data1 /data2
-rw-r--r--    1 root     root          4349 Jun 22 10:20 /data1

/data2:
total 24
drwxr-xr-x    5 root     root          4096 Jun 22 10:20 .
drwxr-xr-x   14 root     root          4096 Jun 22 10:20 ..
drwxr-xr-x    8 root     root          4096 Jun 22 10:20 .git
-rw-r--r--    1 root     root           453 Jun 22 10:20 README.md
drwxr-xr-x    4 root     root          4096 Jun 22 10:20 mainline
drwxr-xr-x    4 root     root          4096 Jun 22 10:20 stable
```