### PR TITLE
use -b option to specify git source branch

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -116,6 +116,15 @@ func checkSourceType(source string) string {
 	}
 }
 
+func parseGitSource(source string) (string, string) {
+	idx := strings.LastIndex(source, ".git:")
+	if idx == -1 {
+		return source, "master"
+	}
+
+	return source[:idx+4], source[idx+5:]
+}
+
 func (cli *DockerCli) initSpecialVolumes(config *container.Config, hostConfig *container.HostConfig, networkingConfig *networktypes.NetworkingConfig, initvols []*InitVolume) error {
 	const INIT_VOLUME_PATH = "/vol/"
 	const INIT_VOLUME_IMAGE = "hyperhq/volume_uploader:v1"
@@ -175,7 +184,8 @@ func (cli *DockerCli) initSpecialVolumes(config *container.Config, hostConfig *c
 		volType := checkSourceType(vol.Source)
 		switch volType {
 		case "git":
-			cmd = append(cmd, "git", "clone", vol.Source, INIT_VOLUME_PATH+vol.Destination)
+			source, branch := parseGitSource(vol.Source)
+			cmd = append(cmd, "git", "clone", source, "-b", branch, INIT_VOLUME_PATH+vol.Destination)
 		case "http":
 			isFile, err := fileSourceVolume(vol.Source)
 			if err != nil {


### PR DESCRIPTION
```
[lear@hypervisor]$pkt run -d -v http://git.kernel.org/pub/scm/utils/util-linux/util-linux.git:stable/v2.13.0:/data busybox
a3d54039c7fc28454c68dfb5ba24e73d807a914ce08dd544dc678be0b5b4bd10
[lear@hypervisor]$pkt exec -t a3d54039c7fc28454c68dfb5ba24e73d807a914ce08dd544dc678be0b5b4bd10 ls /data
AUTHORS           README.licensing  fdisk             mount
COPYING           TODO              getopt            partx
DEPRECATED        autogen.sh        hwclock           po
INSTALL           config            include           schedutils
Makefile.am       configure.ac      lib               sys-utils
NEWS              disk-utils        licenses          tests
README            docs              login-utils       text-utils
README.devel      example.files     misc-utils        tools
```

```
[lear@hypervisor]$pkt run -d -v http://git.kernel.org/pub/scm/utils/util-linux/util-linux.git:/data busybox
1af3058b03981d19e4332edac94e2d3896f267cb649b760ee708288f12f40560
[lear@hypervisor]$pkt exec -t 1af3058b03981d19e4332edac94e2d3896f267cb649b760ee708288f12f40560 ls /data
AUTHORS           autogen.sh        libfdisk          schedutils
COPYING           bash-completion   libmount          sys-utils
ChangeLog         config            libsmartcols      term-utils
Documentation     configure.ac      libuuid           tests
Makefile.am       disk-utils        login-utils       text-utils
NEWS              include           m4                tools
README            lib               misc-utils        util-linux.doap
README.licensing  libblkid          po
```