### PR TITLE
Add volume init tests

### DIFF
--- a/integration-cli/future/cli/hyper_cli_run_local_volume_init_test.go
+++ b/integration-cli/future/cli/hyper_cli_run_local_volume_init_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"time"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestRunLocalFileVolumeBinding(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "/tmp/hyper_integration_test_local_file_volume_file"
+	ioutil.WriteFile(source, []byte("foo"), 0644)
+
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Equals, "foo")
+	dockerCmd(c, "rm", "-fv", "voltest")
+
+	exec.Command("rm", "-f", source).CombinedOutput()
+}
+
+func (s *DockerSuite) TestRunLocalDirVolumeBinding(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	dir := "/tmp/hyper_integration_test_local_dir_volume_dir"
+	file := "datafile"
+	exec.Command("mkdir", "-p", dir).CombinedOutput()
+	ioutil.WriteFile(dir+"/"+file, []byte("foo"), 0644)
+
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", dir+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/"+file)
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Equals, "foo")
+	dockerCmd(c, "rm", "-fv", "voltest")
+
+	exec.Command("rm", "-r", dir).CombinedOutput()
+}
+
+func (s *DockerSuite) TestRunLocalDeepDirVolumeBinding(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	dir := "/tmp/hyper_integration_test_local_dir_volume_dir"
+	middle_dir := "/dir1/dir2/dir3/dir4/dir5"
+	file := "datafile"
+	exec.Command("mkdir", "-p", dir+"/"+middle_dir).CombinedOutput()
+	ioutil.WriteFile(dir+"/"+middle_dir+"/"+file, []byte("foo"), 0644)
+
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", dir+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/"+middle_dir+"/"+file)
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Equals, "foo")
+	dockerCmd(c, "rm", "-fv", "voltest")
+
+	exec.Command("rm", "-r", dir).CombinedOutput()
+}
+
+func (s *DockerSuite) TestRunLocalNonexistingVolumeBinding(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	dir := "/tmp/nosuchfile"
+	_, _, err := dockerCmdWithError("run", "-d", "--name=voltest", "-v", dir+":/data", "busybox")
+	c.Assert(err, checker.NotNil)
+}

--- a/integration-cli/future/cli/hyper_cli_run_remote_volume_init_test.go
+++ b/integration-cli/future/cli/hyper_cli_run_remote_volume_init_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"time"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestRunHttpFileVolumeBinding(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "https://raw.githubusercontent.com/hyperhq/hypercli/master/README.md"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "stat", "/data")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "regular file")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunHttpsFileVolumeBinding(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "https://raw.githubusercontent.com/hyperhq/hypercli/master/README.md"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "stat", "/data")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "regular file")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunGitVolumeBinding(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/README")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "util-linux")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunGitBranchVolumeBinding(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git:stable/v2.13.0"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/configure.ac")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "2.13.0")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunHttpGitVolumeBinding(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "http://git.kernel.org/pub/scm/utils/util-linux/util-linux.git"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/README")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "util-linux")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunHttpGitBranchVolumeBinding(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "http://git.kernel.org/pub/scm/utils/util-linux/util-linux.git:stable/v2.13.0"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/configure.ac")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "2.13.0")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunHttpsGitVolumeBinding(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/README")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "util-linux")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunHttpsGitBranchVolumeBinding(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "http://git.kernel.org/pub/scm/utils/util-linux/util-linux.git:stable/v2.13.0"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/README")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "util-linux")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunNonexistingHttpFileVolumeBinding(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "https://raw.githubusercontent.com/nosuchuser/nosuchrepo/masterbeta/README.md"
+	_, _, err := dockerCmdWithError("run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.NotNil)
+}

--- a/integration-cli/future/cli/hyper_cli_volume_reload_test.go
+++ b/integration-cli/future/cli/hyper_cli_volume_reload_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"time"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestRunHttpFileVolumeRestartReload(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "https://raw.githubusercontent.com/hyperhq/hypercli/master/README.md"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	_, err = dockerCmd(c, "restart", "--reload")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "stat", "/data")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "regular file")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunHttpsFileVolumeRestartReload(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "https://raw.githubusercontent.com/hyperhq/hypercli/master/README.md"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	_, err = dockerCmd(c, "restart", "--reload")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "stat", "/data")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "regular file")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunGitVolumeRestartReload(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	_, err = dockerCmd(c, "restart", "--reload")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/README")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "util-linux")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunGitBranchVolumeRestartReload(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git:stable/v2.13.0"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	_, err = dockerCmd(c, "restart", "--reload")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/configure.ac")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "2.13.0")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunHttpGitVolumeRestartReload(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "http://git.kernel.org/pub/scm/utils/util-linux/util-linux.git"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	_, err = dockerCmd(c, "restart", "--reload")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/README")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "util-linux")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunHttpGitBranchVolumeRestartReload(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "http://git.kernel.org/pub/scm/utils/util-linux/util-linux.git:stable/v2.13.0"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	_, err = dockerCmd(c, "restart", "--reload")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/configure.ac")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "2.13.0")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunHttpsGitVolumeRestartReload(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	_, err = dockerCmd(c, "restart", "--reload")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/README")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "util-linux")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunHttpsGitBranchVolumeRestartReload(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "http://git.kernel.org/pub/scm/utils/util-linux/util-linux.git:stable/v2.13.0"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	_, err = dockerCmd(c, "restart", "--reload")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/README")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "util-linux")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunNoVolumeRestartReload(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	_, err = dockerCmd(c, "restart", "--reload")
+	c.Assert(err, checker.Equals, 0)
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestRunLocalFileVolumeRestartReload(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "/tmp/hyper_integration_test_local_file_volume_file"
+	ioutil.WriteFile(source, []byte("foo"), 0644)
+
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Equals, "foo")
+
+	ioutil.WriteFile(source, []byte("bar"), 0644)
+	_, err = dockerCmd(c, "restart", "--reload")
+	c.Assert(err, checker.Equals, 0)
+	out, err = dockerCmd(c, "exec", "voltest", "cat", "/data")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Equals, "bar")
+
+	dockerCmd(c, "rm", "-fv", "voltest")
+	exec.Command("rm", "-f", source).Output()
+}
+
+func (s *DockerSuite) TestRunLocalDirVolumeRestartReload(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	dir := "/tmp/hyper_integration_test_local_dir_volume_dir"
+	file := "datafile"
+	exec.Command("mkdir", "-p", dir).Output()
+	ioutil.WriteFile(dir+"/"+file, []byte("foo"), 0644)
+
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", dir+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data/"+file)
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Equals, "foo")
+
+	ioutil.WriteFile(dir+"/"+file, []byte("bar"), 0644)
+	_, err = dockerCmd(c, "restart", "--reload")
+	c.Assert(err, checker.Equals, 0)
+	out, err = dockerCmd(c, "exec", "voltest", "cat", "/data/"+file)
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Equals, "bar")
+
+	dockerCmd(c, "rm", "-fv", "voltest")
+	exec.Command("rm", "-r", dir).Output()
+}
+
+func (s *DockerSuite) TestRunLocalFileVolumeStartReload(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	source := "/tmp/hyper_integration_test_local_file_volume_file"
+	ioutil.WriteFile(source, []byte("foo"), 0644)
+
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", source+":/data", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "cat", "/data")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Equals, "foo")
+
+	ioutil.WriteFile(source, []byte("bar"), 0644)
+	_, err = dockerCmd(c, "stop", "voltest")
+	c.Assert(err, checker.Equals, 0)
+	_, err = dockerCmd(c, "start", "--reload")
+	c.Assert(err, checker.Equals, 0)
+	out, err = dockerCmd(c, "exec", "voltest", "cat", "/data")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Equals, "bar")
+
+	dockerCmd(c, "rm", "-fv", "voltest")
+	exec.Command("rm", "-f", source).Output()
+}


### PR DESCRIPTION
Tests cover `hyper run -v remote:/data`, `hyper run -v local_path:/data`, `hyper start --reload` and `hyper restart --reload`.