### PR TITLE
fix volumeSplitN

### DIFF
--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -726,6 +726,15 @@ func volumeSplitN(raw string, n int) []string {
 					numberOfParts++
 				}
 				// else, `C:` is considered as a drive letter and not as a delimiter, so we continue parsing.
+			} else if right != len(raw)-1 {
+				// check next to see if this is a windows partition
+				next := raw[right+1]
+				if next != '\\' {
+					// C: is a single character volume name
+					array = append(array, raw[left:right])
+					left = right + 1
+					numberOfParts++
+				}
 			}
 			// if right == 1, then `C:` is the beginning of the raw string, therefore `:` is again not considered a delimiter and we continue parsing.
 		} else {


### PR DESCRIPTION
If volume name is a single character, check next character to see if
it is a windows partition. If not, consider it to be a valid volume
name.

Test results:
```
[lear@blog-examples]$mypkt volume create --name f
f
[lear@blog-examples]$mypkt run -d -v f:/data busybox
236f16512fe2ff40173927096799fa41d12b7ebb62ba482394f451289eafe866
[lear@blog-examples]$mypkt volume ls
DRIVER              VOLUME NAME                                                       SIZE                CONTAINER
hyper               f                                                                 10 GB               236f16512fe2
[lear@blog-examples]$mypkt exec 236f16512fe2ff40173927096799fa41d12b7ebb62ba482394f451289eafe866 df
Filesystem           1K-blocks      Used Available Use% Mounted on
/dev/sdb              10190100     38060   9611368   0% /
devtmpfs                250392         0    250392   0% /dev
tmpfs                   253336         0    253336   0% /dev/shm
/dev/sda              10190100     36892   9612536   0% /data
share_dir                 1024         4      1020   0% /etc/hosts
```