### PR TITLE
add hyper run --noauto-volume tests

### DIFF
--- a/integration-cli/future/cli/hyper_cli_run_noauto_volume_test.go
+++ b/integration-cli/future/cli/hyper_cli_run_noauto_volume_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"strings"
+	"time"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+// Image volume mounted at directory "/data1"
+func (s *DockerSuite) TestVerifyNoautoVolumeBaseImage(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "hyperhq/noauto_volume_test")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "df", "/data1")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(strings.Contains(string(out), "data1"), checker.True, check.Commentf("got df results: %s", string(out)))
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+// No volume mounted at directory "/data1"
+func (s *DockerSuite) TestNoautoVolume(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	_, err := dockerCmd(c, "run", "-d", "--noauto-volume", "--name=voltest", "hyperhq/noauto_volume_test")
+	c.Assert(err, checker.Equals, 0)
+	_, exitCode, _ := dockerCmdWithError("exec", "voltest", "ls", "/data1")
+	c.Assert(exitCode, checker.GreaterThan, 0)
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestImplicitOverwriteNoautoVolume(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	_, err := dockerCmd(c, "run", "-d", "--noauto-volume", "--name=voltest", "-v", "/data1", "hyperhq/noauto_volume_test")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "df", "/data1")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(strings.Contains(string(out), "data1"), checker.True, check.Commentf("got df results: %s", string(out)))
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestNamedOverwriteNoautoVolume(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	volName := "testvolume"
+	_, err := dockerCmd(c, "run", "-d", "--noauto-volume", "--name=voltest", "-v", volName+":/data1", "hyperhq/noauto_volume_test")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "df", "/data1")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(strings.Contains(string(out), "data1"), checker.True, check.Commentf("got df results: %s", string(out)))
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestNoautoAndNormalVolume(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	volName := "testvolume"
+	_, err := dockerCmd(c, "run", "-d", "--noauto-volume", "--name=voltest", "-v", volName+":/vol/data", "hyperhq/noauto_volume_test")
+	c.Assert(err, checker.Equals, 0)
+	_, exitCode, _ := dockerCmdWithError("exec", "voltest", "ls", "/data1")
+	c.Assert(exitCode, checker.GreaterThan, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "df", "/vol/data")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(strings.Contains(string(out), "data"), checker.True, check.Commentf("got df /vol/data results: %s", string(out)))
+	dockerCmd(c, "rm", "-fv", "voltest")
+}


### PR DESCRIPTION
Test results:
```
 ⚡  /go/src/github.com/hyperhq/hypercli/integration-cli   noauto-test ●  go test
finish init
INFO: Testing against a remote daemon(tcp://147.75.195.37:6443)
[2016-09-14 03:21:21] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestImplicitOverwriteNoautoVolume - 28.870474 sec
[2016-09-14 03:22:12] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestNamedOverwriteNoautoVolume - 27.549756 sec
[2016-09-14 03:22:58] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestNoautoAndNormalVolume - 52.835125 sec
[2016-09-14 03:24:08] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestNoautoVolume - 27.693281 sec
[2016-09-14 03:25:12] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestVerifyNoautoVolumeBaseImage - 45.923531 sec
OK: 5 passed
PASS
ok      github.com/hyperhq/hypercli/integration-cli     319.682s
```