### PR TITLE
add volume populate tests

### DIFF
--- a/integration-cli/future/cli/hyper_cli_volume_populate_test.go
+++ b/integration-cli/future/cli/hyper_cli_volume_populate_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"time"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestPopulateImplicitVolume(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	volName := "testvolume"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", volName+":/etc", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "ls", "/etc")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "passwd")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestPopulateNamedVolume(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	volName := "testvolume"
+	_, err := dockerCmd(c, "volume", "create", "--name", volName)
+	c.Assert(err, checker.Equals, 0)
+	_, err = dockerCmd(c, "run", "-d", "--name=voltest", "-v", volName+":/etc", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "ls", "/etc")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(out, checker.Contains, "passwd")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestPopulateMultiMountImplicitVolume(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	volName := "testvolume"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "-v", volName+":/lib/modules/", "-v", volName+":/tmp", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "ls", "/lib/modules")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(string(out), checker.HasLen, 0)
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestPopulateMultiMountNamedVolume(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	volName := "testvolume"
+	_, err := dockerCmd(c, "volume", "create", "--name", volName)
+	c.Assert(err, checker.Equals, 0)
+	_, err = dockerCmd(c, "run", "-d", "--name=voltest", "-v", volName+":/lib/modules/", "-v", volName+":/tmp", "busybox")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "ls", "/lib/modules")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(string(out), checker.HasLen, 0)
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestPopulateImageVolume(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "--size=l1", "neo4j")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "ls", "/data")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(string(out), checker.Contains, "databases")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}
+
+func (s *DockerSuite) TestPopulateNamedImageVolume(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	volName := "testvolume"
+	_, err := dockerCmd(c, "run", "-d", "--name=voltest", "--size=l1", "-v", volName+":/data", "neo4j")
+	c.Assert(err, checker.Equals, 0)
+	out, err := dockerCmd(c, "exec", "voltest", "ls", "/data")
+	c.Assert(err, checker.Equals, 0)
+	c.Assert(string(out), checker.Contains, "databases")
+	dockerCmd(c, "rm", "-fv", "voltest")
+}


### PR DESCRIPTION
```
 ✘ ⚡  /go/src/github.com/hyperhq/hypercli/integration-cli   populate-test  go test
finish init
INFO: Testing against a remote daemon(tcp://147.75.195.37:6443)
[2016-09-13 07:09:52] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestPopulateImageVolume - 107.396555 sec
[2016-09-13 07:12:07] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestPopulateImplicitVolume - 22.246503 sec
[2016-09-13 07:12:46] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestPopulateMultiMountImplicitVolume - 27.165430 sec
[2016-09-13 07:13:30] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestPopulateMultiMountNamedVolume - 25.806369 sec
[2016-09-13 07:14:14] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestPopulateNamedImageVolume - 80.185182 sec
[2016-09-13 07:15:59] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestPopulateNamedVolume - 28.354653 sec
OK: 6 passed
PASS
ok      github.com/hyperhq/hypercli/integration-cli     424.072s
```