### PR TITLE
read from environment if the config.json is not existed

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -153,6 +153,9 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, clientFlags *cli.ClientF
 		if ok {
 			cloudConfig.AccessKey = cc.AccessKey
 			cloudConfig.SecretKey = cc.SecretKey
+		} else {
+			cloudConfig.AccessKey = os.Getenv("HYPER_ACCESS")
+			cloudConfig.SecretKey = os.Getenv("HYPER_SECRET")
 		}
 		if cloudConfig.AccessKey == "" || cloudConfig.SecretKey == "" {
 			fmt.Fprintf(cli.err, "WARNING: null cloud config\n")


### PR DESCRIPTION
```
[lei@h8s-single hypercli]$ mv ~/.hyper/config.json /tmp/
[lei@h8s-single hypercli]$ cat ~/.hyper/config.json
cat: /home/lei/.hyper/config.json: No such file or directory
[lei@h8s-single hypercli]$ hyper/hyper ps
WARNING: null cloud config
Error response from daemon: Unauthorized
[lei@h8s-single hypercli]$ export HYPER_ACCESS=XXXXXXXXXXXXXXXXXXXXXXXXX
[lei@h8s-single hypercli]$ export HYPER_SECRET=XXXXXXXXXXXXXXXXXXXXXXXXX000000000000000000
[lei@h8s-single hypercli]$ hyper/hyper ps
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                                              NAMES                 PUBLIC IP
[lei@h8s-single hypercli]$ unset HYPER_ACCESS
[lei@h8s-single hypercli]$ hyper/hyper ps -a
WARNING: null cloud config
Error response from daemon: Unauthorized
[lei@h8s-single hypercli]$ export HYPER_ACCESS=XXXXXXXXXXXXXXXXXXXXXXXXX
[lei@h8s-single hypercli]$ hyper/hyper ps -a
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                   PORTS                                              NAMES                 PUBLIC IP
[lei@h8s-single hypercli]$
```