### PR TITLE
support windows local volume

### DIFF
--- a/api/client/create.go
+++ b/api/client/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/net/context"
@@ -87,6 +88,8 @@ func parseProtoAndLocalBind(bind string) (string, string, bool) {
 		if strings.Count(bind, ":") < 1 {
 			return "", "", false
 		}
+	case filepath.VolumeName(bind) != "":
+		// Windows local path
 	default:
 		return "", "", false
 	}

--- a/api/client/utils_unix.go
+++ b/api/client/utils_unix.go
@@ -9,3 +9,11 @@ import (
 func getContextRoot(srcPath string) (string, error) {
 	return filepath.Join(srcPath, "."), nil
 }
+
+func convertToUnixPath(path string) (int, string) {
+	return 0, path
+}
+
+func recoverPath(pathType int, path string) string {
+	return path
+}

--- a/api/client/utils_windows.go
+++ b/api/client/utils_windows.go
@@ -4,8 +4,15 @@ package client
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/hyperhq/hypercli/pkg/longpath"
+)
+
+const (
+	LOCAL_PATH_UNIX = iota
+	LOCAL_PATH_WIN_VOLUME
+	LOCAL_PATH_WIN_SHARE
 )
 
 func getContextRoot(srcPath string) (string, error) {
@@ -14,4 +21,40 @@ func getContextRoot(srcPath string) (string, error) {
 		return "", err
 	}
 	return longpath.AddPrefix(cr), nil
+}
+
+// convertToUnixPath converts whatever valid path to unix format
+// network path is treated as unix path unchanged
+// /foo/bar -> /foo/bar
+// C:\foo\bar -> /C/foo/bar
+// \\host\share\foo\bar -> //host/share/foo/bar
+func convertToUnixPath(path string) (int, string) {
+	if strings.HasPrefix(path, "git://") || strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return LOCAL_PATH_UNIX, path
+	}
+	switch len(filepath.VolumeName(path)) {
+	case 0:
+		return LOCAL_PATH_UNIX, path
+	case 2:
+		// C:
+		return LOCAL_PATH_WIN_VOLUME, "/" + strings.Replace(filepath.ToSlash(path), ":", "", 1)
+	default:
+		// \\host\share
+		return LOCAL_PATH_WIN_SHARE, filepath.ToSlash(path)
+	}
+}
+
+// recoverPath recovers a file path according to path type
+func recoverPath(pathType int, path string) string {
+	switch pathType {
+	case LOCAL_PATH_WIN_VOLUME:
+		path = filepath.FromSlash(path)
+		return strings.Replace(path[1:], "\\", ":\\", 1)
+	case LOCAL_PATH_WIN_SHARE:
+		return filepath.FromSlash(path)
+	default:
+		// LOCAL_PATH_UNIX
+		return path
+	}
+
 }


### PR DESCRIPTION
For windows local volume, convert windows path to unix slash style and revert the result when uploading.

On Windows:
```
C:\bergwolf\workspace\src\github.com\hyperhq\hypercli\hyper>hyper.exe run -d -v
C:\bergwolf\workspace\src\github.com\hyperhq\hypercli\api\client:/data busybox
Sending client 71 / 71 [===========================================] 100.00% 4s
1645fe8a268e427a645bc93268bd4b38aa083aa3f8983c565d0f130c3fc18256
```

On Linux:
```
$hyper run -d -v `pwd`:/data busybox
Sending test-data 3 / 3 [==========================================] 100.00% 4s
e259eb73194f220c217d2742adb05c5a58bcc97697453031c1d55f8ac64bd91d
```

Fixes https://github.com/hyperhq/hypercli/issues/193