### PR TITLE
add format option for hyper volume ls

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -83,6 +83,12 @@ func (cli *DockerCli) ImagesFormat() string {
 	return cli.configFile.ImagesFormat
 }
 
+// VolumesFormat returns the format string specified in the configuration.
+// String contains columns and format specification, for example {{ID}}\t{{Name}}.
+func (cli *DockerCli) VolumesFormat() string {
+	return cli.configFile.VolumesFormat
+}
+
 func (cli *DockerCli) setRawTerminal() error {
 	if cli.isTerminalIn && os.Getenv("NORAW") == "" {
 		state, err := term.SetRawTerminal(cli.inFd)

--- a/api/client/formatter/custom.go
+++ b/api/client/formatter/custom.go
@@ -6,33 +6,37 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/engine-api/types"
+	"github.com/docker/go-units"
 	"github.com/hyperhq/hypercli/api"
 	"github.com/hyperhq/hypercli/pkg/stringid"
 	"github.com/hyperhq/hypercli/pkg/stringutils"
-	"github.com/docker/engine-api/types"
-	"github.com/docker/go-units"
 )
 
 const (
 	tableKey = "table"
 	fipLabel = "sh.hyper.fip"
 
-	containerIDHeader  = "CONTAINER ID"
-	imageHeader        = "IMAGE"
-	namesHeader        = "NAMES"
-	commandHeader      = "COMMAND"
-	createdSinceHeader = "CREATED"
-	createdAtHeader    = "CREATED AT"
-	runningForHeader   = "CREATED"
-	statusHeader       = "STATUS"
-	portsHeader        = "PORTS"
-	sizeHeader         = "SIZE"
-	labelsHeader       = "LABELS"
-	imageIDHeader      = "IMAGE ID"
-	repositoryHeader   = "REPOSITORY"
-	tagHeader          = "TAG"
-	digestHeader       = "DIGEST"
-	fipHeader          = "PUBLIC IP"
+	containerIDHeader     = "CONTAINER ID"
+	imageHeader           = "IMAGE"
+	namesHeader           = "NAMES"
+	commandHeader         = "COMMAND"
+	createdSinceHeader    = "CREATED"
+	createdAtHeader       = "CREATED AT"
+	runningForHeader      = "CREATED"
+	statusHeader          = "STATUS"
+	portsHeader           = "PORTS"
+	sizeHeader            = "SIZE"
+	labelsHeader          = "LABELS"
+	imageIDHeader         = "IMAGE ID"
+	repositoryHeader      = "REPOSITORY"
+	tagHeader             = "TAG"
+	digestHeader          = "DIGEST"
+	fipHeader             = "PUBLIC IP"
+	volumeNameHeader      = "NAME"
+	volumeSizeHeader      = "SIZE"
+	volumeDriverHeader    = "DRIVER"
+	volumeContainerHeader = "CONTAINER"
 )
 
 type containerContext struct {
@@ -199,6 +203,33 @@ func (c *imageContext) CreatedAt() string {
 func (c *imageContext) Size() string {
 	c.addHeader(sizeHeader)
 	return units.HumanSize(float64(c.i.Size))
+}
+
+type volumeContext struct {
+	baseSubContext
+	i types.Volume
+}
+
+func (c *volumeContext) Name() string {
+	c.addHeader(volumeNameHeader)
+	return c.i.Name
+}
+
+func (c *volumeContext) Size() string {
+	c.addHeader(volumeSizeHeader)
+	size := c.i.Labels["size"]
+	return size + " GB"
+}
+
+func (c *volumeContext) Driver() string {
+	c.addHeader(volumeDriverHeader)
+	return c.i.Driver
+}
+
+func (c *volumeContext) Container() string {
+	c.addHeader(volumeContainerHeader)
+	container := c.i.Labels["container"]
+	return container
 }
 
 type subContext interface {

--- a/cliconfig/config.go
+++ b/cliconfig/config.go
@@ -54,13 +54,14 @@ type CloudConfig struct {
 
 // ConfigFile ~/.docker/config.json file info
 type ConfigFile struct {
-	AuthConfigs  map[string]types.AuthConfig `json:"auths"`
-	CloudConfig  map[string]CloudConfig      `json:"clouds"`
-	HTTPHeaders  map[string]string           `json:"HttpHeaders,omitempty"`
-	PsFormat     string                      `json:"psFormat,omitempty"`
-	ImagesFormat string                      `json:"imagesFormat,omitempty"`
-	DetachKeys   string                      `json:"detachKeys,omitempty"`
-	filename     string                      // Note: not serialized - for internal use only
+	AuthConfigs   map[string]types.AuthConfig `json:"auths"`
+	CloudConfig   map[string]CloudConfig      `json:"clouds"`
+	HTTPHeaders   map[string]string           `json:"HttpHeaders,omitempty"`
+	PsFormat      string                      `json:"psFormat,omitempty"`
+	ImagesFormat  string                      `json:"imagesFormat,omitempty"`
+	VolumesFormat string                      `json:"volumesFormat,omitempty"`
+	DetachKeys    string                      `json:"detachKeys,omitempty"`
+	filename      string                      // Note: not serialized - for internal use only
 }
 
 // NewConfigFile initializes an empty configuration file for the given filename 'fn'


### PR DESCRIPTION
```
[lei@h8s-single hypercli]$ hyper volume ls --format {{.Name}}
data
8bf2850f2d51231c8c9fc72a7afa5574cca7086f8a8ad96126b380cf600f885
bbaddb4be4c0a63f086f6b7019daa2218a271f4bdca5bd439061ceee6df2c56
test2
test1
[lei@h8s-single hypercli]$ hyper volume ls --format {{.Size}}
10 GB
10 GB
10 GB
10 GB
10 GB
[lei@h8s-single hypercli]$ hyper volume ls
DRIVER              NAME                                                              SIZE                CONTAINER
hyper               data                                                              10 GB
hyper               8bf2850f2d51231c8c9fc72a7afa5574cca7086f8a8ad96126b380cf600f885   10 GB               973772d1a02c4a747b1d1798a2accd0fb134d4a188ef6e61d0282851dabb7655
hyper               bbaddb4be4c0a63f086f6b7019daa2218a271f4bdca5bd439061ceee6df2c56   10 GB               973772d1a02c4a747b1d1798a2accd0fb134d4a188ef6e61d0282851dabb7655
hyper               test2                                                             10 GB
hyper               test1                                                             10 GB
```