### PR TITLE
add test case for load local

### DIFF
--- a/integration-cli/README.md
+++ b/integration-cli/README.md
@@ -33,6 +33,8 @@ Integration test for hyper cli
 	- [if test case will be supported in the future](#if-test-case-will-be-supported-in-the-future)
 - [After issues fixed](#after-issues-fixed)
 
+- [Run test on localhost](#run-test-on-localhost)
+
 <!-- /TOC -->
 
 # Project status
@@ -292,3 +294,50 @@ ok      github.com/hyperhq/hypercli/integration-cli    ?s
 
 - move the test case from `integration-cli/issue` to `integration-cli` dir
 - go to [start test](#start-test)
+
+
+# Run test on localhost
+
+## prepare
+
+```
+// ensure hyperhq and docker dir
+mkdir -p $GOPATH/src/github.com/{hyperhq,docker}
+
+// clone and build hypercli
+cd $GOPATH/src/github.com/hyperhq
+git clone git@github.com:hyperhq/hypercli.git
+cd hypercli
+./build.sh
+
+// copy hyper binary to /usr/bin/hyper
+sudo cp hyper/hyper /usr/bin/hyper
+
+// create link
+cd $GOPATH/src/github.com/docker
+ln -s ../hyperhq/hypercli docker
+
+// generate util.conf
+$ git checkout integration-test
+$ cd integration-cli
+$ ./util.sh
+
+// config util.conf
+$ vi util.conf
+HYPER_CONFIG=<$HOME/.hyper>
+ACCESS_KEY="<hyper access key>"
+SECRET_KEY="<hyper secret key>"
+```
+
+## run test case
+
+```
+// run all test cases
+$ ./util.sh test
+
+// run specified test case
+$ ./util.sh test TestLoadFromLocalTar$
+
+// run test cases start with specified prefix
+$ ./util.sh test TestLoadFromLocalTar
+```

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -23,8 +23,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/integration"
+	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/stringutils"
 	HyperCli "github.com/docker/engine-api/client"
@@ -32,10 +36,6 @@ import (
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/go-check/check"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/docker/docker/pkg/integration/checker"
 )
 
 var flag_host = ""
@@ -622,7 +622,7 @@ func newRequestClient(method, endpoint string, data io.Reader, ct string) (*http
 	client := httputil.NewClientConn(c, nil)
 
 	//save to postData
-	postData := fmt.Sprintf("%v",data)
+	postData := fmt.Sprintf("%v", data)
 
 	req, err := http.NewRequest(method, fmt.Sprintf("/v1.23%s", endpoint), data)
 	if err != nil {
@@ -644,13 +644,13 @@ func newRequestClient(method, endpoint string, data io.Reader, ct string) (*http
 	if endpoint == debugEndpoint {
 		//output curl command line
 		fmt.Println("\n--------------------------------------------------------------------------------------------")
-		fmt.Printf("debugEndpoint: %v (expired after 5min)\n",debugEndpoint)
+		fmt.Printf("debugEndpoint: %v (expired after 5min)\n", debugEndpoint)
 		fmt.Println("--------------------------------------------------------------------------------------------")
 		fmt.Println("curl -v -k \\")
 		for k, v := range req.Header {
 			fmt.Printf("  -H \"%v: %v\" \\\n", k, v[0])
 		}
-		fmt.Printf("  -X %v \\\n",  method )
+		fmt.Printf("  -X %v \\\n", method)
 		if req.Body != nil {
 			fmt.Printf("  -d '%v' \\\n", postData)
 		}
@@ -777,7 +777,6 @@ func getAllSnapshots() ([]*types.Snapshot, error) {
 	}
 	return snapshots.Snapshots, nil
 }
-
 
 func deleteAllVolumes() error {
 	volumes, err := getAllVolumes()
@@ -932,6 +931,14 @@ func pullImageIfNotExist(image string) error {
 		}
 	}
 	return nil
+}
+
+func pathExist(_path string) bool {
+	_, err := os.Stat(_path)
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+	return true
 }
 
 func dockerCmdWithError(args ...string) (string, int, error) {
@@ -1881,7 +1888,7 @@ func printTestDuration(start time.Time) {
 	fmt.Printf(" - %.6f sec\n", duration)
 }
 
-func generateS3PreSignedURL(region,s3bucket,s3key string) (string, error) {
+func generateS3PreSignedURL(region, s3bucket, s3key string) (string, error) {
 
 	accessKey := os.Getenv("AWS_ACCESS_KEY")
 	secretKey := os.Getenv("AWS_SECRET_KEY")
@@ -1892,7 +1899,7 @@ func generateS3PreSignedURL(region,s3bucket,s3key string) (string, error) {
 
 	s3cli := s3.New(&aws.Config{
 		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, ""),
-		Region: &region,
+		Region:      &region,
 	})
 
 	r, _ := s3cli.GetObjectRequest(&s3.GetObjectInput{
@@ -1917,10 +1924,10 @@ func getImageInspect(c *check.C, imageName string) *types.ImageInspect {
 	return &image
 }
 
-func ensureImageExist(c *check.C, imageName string){
+func ensureImageExist(c *check.C, imageName string) {
 	for i := 0; i < 3; i++ {
 		if _err := pullImageIfNotExist(imageName); _err != nil {
-			c.Logf("couldn't find the %s image locally and failed to pull it, try againt\n",imageName)
+			c.Logf("couldn't find the %s image locally and failed to pull it, try againt\n", imageName)
 		} else {
 			break
 		}
@@ -1928,13 +1935,12 @@ func ensureImageExist(c *check.C, imageName string){
 }
 
 //get containerId or imageId from hyper command output
-func getIDfromOutput(c *check.C, output string)(string){
+func getIDfromOutput(c *check.C, output string) string {
 	outAry := strings.Split(output, "\n")
-	c.Assert(len(outAry), checker.GreaterOrEqualThan,2)
+	c.Assert(len(outAry), checker.GreaterOrEqualThan, 2)
 	id := outAry[len(outAry)-2]
 	return strings.TrimSpace(id)
 }
-
 
 func checkImage(c *check.C, shouldExist bool, imageName string) {
 	images, _ := dockerCmd(c, "images", imageName)

--- a/integration-cli/hyper_cli_load_local_test.go
+++ b/integration-cli/hyper_cli_load_local_test.go
@@ -1,0 +1,366 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+//test normal///////////////////////////////////////////////////////////////////////////
+func (s *DockerSuite) TestLoadFromLocalTarPipe(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	testRequires(c, DaemonIsLinux)
+
+	publicURL := "http://image-tarball.s3.amazonaws.com/test/public/helloworld.tar"
+	imagePath := fmt.Sprintf("%s/helloworld.tar", os.Getenv("IMAGE_DIR"))
+
+	//download image tar
+	wgetCmd := exec.Command("wget", "-cO", imagePath, publicURL)
+	_, exitCode, err := runCommandWithOutput(wgetCmd)
+	c.Assert(pathExist(imagePath), checker.Equals, true)
+	c.Assert(exitCode, checker.Equals, 0)
+	c.Assert(err, checker.IsNil)
+
+	//load via pipe
+	catCmd := exec.Command("cat", imagePath)
+	loadCmd := exec.Command(dockerBinary, "-H", os.Getenv("DOCKER_HOST"), "--config", os.Getenv("HYPER_CONFIG"), "load", "-i", imagePath)
+
+	catOut, err := catCmd.StdoutPipe()
+	catCmd.Start()
+
+	loadCmd.Stdin = catOut
+	output, err := loadCmd.Output()
+	c.Assert(string(output), checker.Contains, "has been loaded.")
+	c.Assert(err, checker.IsNil)
+
+	//check image
+	images, _ := dockerCmd(c, "images", "hello-world")
+	c.Assert(images, checker.Contains, "hello-world")
+}
+
+func (s *DockerSuite) TestLoadFromLocalTar(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	testRequires(c, DaemonIsLinux)
+
+	publicURL := "http://image-tarball.s3.amazonaws.com/test/public/helloworld.tar"
+	imagePath := fmt.Sprintf("%s/helloworld.tar", os.Getenv("IMAGE_DIR"))
+
+	//download image tar
+	wgetCmd := exec.Command("wget", "-cO", imagePath, publicURL)
+	output, exitCode, err := runCommandWithOutput(wgetCmd)
+	c.Assert(pathExist(imagePath), checker.Equals, true)
+	c.Assert(exitCode, checker.Equals, 0)
+	c.Assert(err, checker.IsNil)
+
+	//load image tar
+	output, exitCode, err = dockerCmdWithError("load", "-i", imagePath)
+	c.Assert(output, checker.Contains, "has been loaded.")
+	c.Assert(err, checker.IsNil)
+	c.Assert(exitCode, checker.Equals, 0)
+
+	//check image
+	images, _ := dockerCmd(c, "images", "hello-world")
+	c.Assert(images, checker.Contains, "hello-world")
+}
+
+func (s *DockerSuite) TestLoadFromLocalTarDelta(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	testRequires(c, DaemonIsLinux)
+
+	baseURL := "https://image-tarball.s3.amazonaws.com/test/public/debian_stretch-slim.tar.gz"
+	basePath := fmt.Sprintf("%s/debian_stretch-slim.tar.gz", os.Getenv("IMAGE_DIR"))
+
+	publicURL := "https://image-tarball.s3.amazonaws.com/test/public/nginx_stable.tar.gz"
+	imagePath := fmt.Sprintf("%s/nginx_stable.tar.gz", os.Getenv("IMAGE_DIR"))
+
+	//download base image tar
+	wgetCmd := exec.Command("wget", "-cO", basePath, baseURL)
+	output, exitCode, err := runCommandWithOutput(wgetCmd)
+	c.Assert(exitCode, checker.Equals, 0)
+	c.Assert(err, checker.IsNil)
+	c.Assert(pathExist(basePath), checker.Equals, true)
+
+	wgetCmd = exec.Command("wget", "-cO", imagePath, publicURL)
+	output, exitCode, err = runCommandWithOutput(wgetCmd)
+	c.Assert(exitCode, checker.Equals, 0)
+	c.Assert(err, checker.IsNil)
+	c.Assert(pathExist(imagePath), checker.Equals, true)
+
+	//load image tar
+	output, exitCode, err = dockerCmdWithError("load", "-i", basePath)
+	c.Assert(output, checker.Contains, "has been loaded.")
+	c.Assert(err, checker.IsNil)
+	c.Assert(exitCode, checker.Equals, 0)
+
+	output, exitCode, err = dockerCmdWithError("load", "-i", imagePath)
+	c.Assert(output, checker.Contains, "has been loaded.")
+	c.Assert(err, checker.IsNil)
+	c.Assert(exitCode, checker.Equals, 0)
+
+	//check image
+	images, _ := dockerCmd(c, "images", "debian:stretch-slim")
+	c.Assert(images, checker.Contains, "debian")
+
+	//check image
+	images, _ = dockerCmd(c, "images", "nginx:stable")
+	c.Assert(images, checker.Contains, "nginx")
+}
+
+func (s *DockerSuite) TestLoadFromLocalCompressedArchive(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	testRequires(c, DaemonIsLinux)
+
+	extAry := [...]string{"tar.gz", "tgz", "tar.bz2", "tar.xz"}
+
+	//download image archive
+	publicURL := ""
+	imagePath := ""
+	for _, val := range extAry {
+		publicURL = "http://image-tarball.s3.amazonaws.com/test/public/helloworld." + val
+		imagePath = fmt.Sprintf("%s/helloworld.%s", os.Getenv("IMAGE_DIR"), val)
+		wgetCmd := exec.Command("wget", "-cO", imagePath, publicURL)
+		_, exitCode, err := runCommandWithOutput(wgetCmd)
+		c.Assert(pathExist(imagePath), checker.Equals, true)
+		c.Assert(err, checker.IsNil)
+		c.Assert(exitCode, checker.Equals, 0)
+	}
+
+	//load image archive
+	for _, val := range extAry {
+		imagePath = fmt.Sprintf("%s/helloworld.%s", os.Getenv("IMAGE_DIR"), val)
+		output, exitCode, err := dockerCmdWithError("load", "-i", imagePath)
+		c.Assert(output, checker.Contains, "has been loaded.")
+		c.Assert(err, checker.IsNil)
+		c.Assert(exitCode, checker.Equals, 0)
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func (s *DockerSuite) TestLoadFromLocalDocker(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	testRequires(c, DaemonIsLinux)
+
+	testImage := "hello-world:latest"
+
+	//local docker pull image
+	pullCmd := exec.Command("docker", "-H", os.Getenv("LOCAL_DOCKER_HOST"), "pull", testImage)
+	output, exitCode, err := runCommandWithOutput(pullCmd)
+	c.Assert(err, checker.IsNil)
+	c.Assert(exitCode, checker.Equals, 0)
+
+	//load image from local docker to hyper
+	output, exitCode, err = dockerCmdWithError("load", "-l", testImage)
+	c.Assert(output, checker.Contains, "has been loaded.")
+	c.Assert(err, checker.IsNil)
+	c.Assert(exitCode, checker.Equals, 0)
+
+	//check image
+	images, _ := dockerCmd(c, "images", "hello-world")
+	c.Assert(images, checker.Contains, "hello-world")
+}
+
+func (s *DockerSuite) TestLoadFromLocalTarSize100MB(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	testRequires(c, DaemonIsLinux)
+
+	publicURL := "https://image-tarball.s3.amazonaws.com/test/public/nginx_stable.tar"
+	imagePath := fmt.Sprintf("%s/nginx_stable.tar", os.Getenv("IMAGE_DIR"))
+
+	//download image tar
+	wgetCmd := exec.Command("wget", "-cO", imagePath, publicURL)
+	output, exitCode, err := runCommandWithOutput(wgetCmd)
+	c.Assert(exitCode, checker.Equals, 0)
+	c.Assert(err, checker.IsNil)
+	c.Assert(pathExist(imagePath), checker.Equals, true)
+
+	//ensure nginx:stable not exist
+	dockerCmdWithError("rmi", "nginx:stable")
+	images, _ := dockerCmd(c, "images", "nginx:stable")
+	c.Assert(images, checker.Not(checker.Contains), "nginx")
+
+	//load image tar
+	output, exitCode, err = dockerCmdWithError("load", "-i", imagePath)
+	c.Assert(output, checker.Contains, "has been loaded.")
+	c.Assert(err, checker.IsNil)
+	c.Assert(exitCode, checker.Equals, 0)
+
+	//check image
+	images, _ = dockerCmd(c, "images", "nginx:stable")
+	c.Assert(images, checker.Contains, "nginx")
+}
+
+//test abnormal///////////////////////////////////////////////////////////////////////////
+func (s *DockerSuite) TestLoadFromLocalMultipeImage(c *check.C) {
+	printTestCaseName()
+	defer printTestDuration(time.Now())
+	testRequires(c, DaemonIsLinux)
+
+	multiImgURL := "http://image-tarball.s3.amazonaws.com/test/public/busybox_alpine.tar"
+	imagePath := fmt.Sprintf("%s/busybox_alpine.tar", os.Getenv("IMAGE_DIR"))
+
+	//download image tar
+	wgetCmd := exec.Command("wget", "-cO", imagePath, multiImgURL)
+	output, exitCode, err := runCommandWithOutput(wgetCmd)
+	c.Assert(pathExist(imagePath), checker.Equals, true)
+	c.Assert(err, checker.IsNil)
+	c.Assert(exitCode, checker.Equals, 0)
+
+	//load image tar
+	output, exitCode, err = dockerCmdWithError("load", "-i", imagePath)
+	c.Assert(output, checker.Contains, "Loading multiple images from local is not supported")
+	c.Assert(err, checker.NotNil)
+	c.Assert(exitCode, checker.Not(checker.Equals), 0)
+
+	//ensure image not exist
+	images, _ := dockerCmd(c, "images", "busybox")
+	c.Assert(images, checker.Not(checker.Contains), "busybox")
+
+	images, _ = dockerCmd(c, "images", "alpine")
+	c.Assert(images, checker.Not(checker.Contains), "alpine")
+}
+
+/*
+// TODO
+//Prerequisite: update image balance to 1 in tenant collection of hypernetes in mongodb
+//db.tenant.update({tenantid:"<tenant_id>"},{$set:{"resourceinfo.balance.images":2}})
+func (s *DockerSuite) TestLoadFromLocalWithQuota(c *check.C) {
+	printTestCaseName(); defer printTestDuration(time.Now())
+	testRequires(c, DaemonIsLinux)
+
+	deleteAllImages()
+
+	helloworldURL := "http://image-tarball.s3.amazonaws.com/test/public/helloworld.tar"
+	multiImgURL := "http://image-tarball.s3.amazonaws.com/test/public/busybox_alpine.tar"
+	ubuntuURL := "http://image-tarball.s3.amazonaws.com/test/public/ubuntu.tar.gz"
+	exceedQuotaMsg := "Exceeded quota, please either delete images, or email support@hyper.sh to request increased quota"
+
+	///// [init] /////
+	// balance 2, images 0
+	out, _ := dockerCmd(c, "info")
+	c.Assert(out, checker.Contains, "Images: 0")
+
+
+	///// [step 1] load new hello-world image /////
+	// balance 2 -> 1, image: 0 -> 1
+	dockerCmd(c, "load", "-i", helloworldURL)
+	images, _ := dockerCmd(c, "images", "hello-world")
+	c.Assert(images, checker.Contains, "hello-world")
+	out, _ = dockerCmd(c, "info")
+	c.Assert(out, checker.Contains, "Images: 1")
+
+
+	///// [step 2] load hello-world image again /////
+	// balance 1 -> 1, image 1 -> 1
+	output, exitCode, err := dockerCmdWithError("load", "-i", helloworldURL)
+	c.Assert(output, checker.Contains, "has been loaded.")
+	c.Assert(exitCode, checker.Equals, 0)
+	c.Assert(err, checker.IsNil)
+
+	checkImage(c, true, "hello-world")
+
+	out, _ = dockerCmd(c, "info")
+	c.Assert(out, checker.Contains, "Images: 1")
+
+
+	///// [step 3] load multiple image(busybox+alpine) /////
+	// balance 1 -> 0, image 1 -> 2
+	output, exitCode, err = dockerCmdWithError("load", "-i", multiImgURL)
+	c.Assert(output, checker.Contains, "has been loaded.")
+	c.Assert(output, checker.Contains, exceedQuotaMsg)
+	c.Assert(exitCode, checker.Equals, 1)
+	c.Assert(err, checker.NotNil)
+
+	checkImage(c, true, "busybox")
+	checkImage(c, false, "alpine")
+
+	out, _ = dockerCmd(c, "info")
+	c.Assert(out, checker.Contains, "Images: 2")
+
+
+	///// [step 4] load hello-world image again /////
+	// balance 0 -> 0, image 2 -> 2
+	output, exitCode, err = dockerCmdWithError("load", "-i", helloworldURL)
+	c.Assert(output, checker.Contains, exceedQuotaMsg)
+	c.Assert(exitCode, checker.Equals, 1)
+	c.Assert(err, checker.NotNil)
+
+	checkImage(c, true, "hello-world")
+
+	out, _ = dockerCmd(c, "info")
+	c.Assert(out, checker.Contains, "Images: 2")
+
+
+	///// [step 5] load new ubuntu image /////
+	// balance 0 -> 0, image 2 -> 2
+	output, exitCode, err = dockerCmdWithError("load", "-i", ubuntuURL)
+	c.Assert(output, checker.Contains, exceedQuotaMsg)
+	c.Assert(exitCode, checker.Equals, 1)
+	c.Assert(err, checker.NotNil)
+
+	checkImage(c, false, "ubuntu")
+
+	out, _ = dockerCmd(c, "info")
+	c.Assert(out, checker.Contains, "Images: 2")
+
+
+	///// [step 6] remove hello-world image /////
+	// balance 0 -> 1, image 2 -> 1
+	images, _ = dockerCmd(c, "rmi", "-f", "hello-world")
+	c.Assert(images, checker.Contains, "Untagged: hello-world:latest")
+
+	checkImage(c, false, "hello-world")
+
+	out, _ = dockerCmd(c, "info")
+	c.Assert(out, checker.Contains, "Images: 1")
+
+
+	///// [step 7] load new ubuntu image again /////
+	//balance 1 -> 0, image 1 -> 2
+	output, exitCode, err = dockerCmdWithError("load", "-i", ubuntuURL)
+	c.Assert(output, checker.Contains, "has been loaded.")
+	c.Assert(exitCode, checker.Equals, 0)
+	c.Assert(err, checker.IsNil)
+
+	checkImage(c, true, "ubuntu")
+
+	out, _ = dockerCmd(c, "info")
+	c.Assert(out, checker.Contains, "Images: 2")
+
+
+	///// [step 8] remove busybox and ubuntu image /////
+	// balance 0 -> 2, image 2 -> 0
+	images, _ = dockerCmd(c, "rmi", "-f", "busybox", "ubuntu:14.04")
+	c.Assert(images, checker.Contains, "Untagged: busybox:latest")
+	c.Assert(images, checker.Contains, "Untagged: ubuntu:14.04")
+
+	checkImage(c, false, "busybox")
+	checkImage(c, false, "ubuntu")
+
+	out, _ = dockerCmd(c, "info")
+	c.Assert(out, checker.Contains, "Images: 0")
+
+
+	///// [step 9] load multiple image(busybox+alpine) again /////
+	// balance 2 -> 0, image 0 -> 2
+	output, exitCode, err = dockerCmdWithError("load", "-i", multiImgURL)
+	c.Assert(output, checker.Contains, "has been loaded.")
+	c.Assert(exitCode, checker.Equals, 0)
+	c.Assert(err, checker.IsNil)
+
+	checkImage(c, true, "busybox")
+	checkImage(c, true, "alpine")
+
+	out, _ = dockerCmd(c, "info")
+	c.Assert(out, checker.Contains, "Images: 2")
+}
+*/

--- a/integration-cli/util.sh
+++ b/integration-cli/util.sh
@@ -10,6 +10,7 @@ Usage: ./util.sh <action>
     build      # build docker image 'hyperhq/hypercl' from Dockerfile.centos
     make       # make hyper cli in container
     enter      # enter container
+    test       # test on host
 EOF
 }
 
@@ -21,15 +22,23 @@ cd ${WORKDIR}
 # ensure util.conf
 if [ ! -s ${WORKDIR}/util.conf ];then
     cat > ${WORKDIR}/util.conf <<EOF
+export GOPATH=\$(pwd)/../vendor:$GOPATH
+export HYPER_CONFIG=\$HOME/.hyperpkt1
+export IMAGE_DIR=/tmp/image
+export LOCAL_DOCKER_HOST="unix:///var/run/docker.sock"
+
+#########################################
+export DOCKER_REMOTE_DAEMON=1
+
 #########################################
 #packet env
 #########################################
 #apirouter service
-DOCKER_HOST=tcp://147.75.195.39:6443
-
+export DOCKER_HOST=tcp://147.75.195.39:6443
 #Hyper Credentials
-ACCESS_KEY=
-SECRET_KEY=
+
+export ACCESS_KEY="8Gxxxxxxxxxxxxxxxxx8JL"
+export SECRET_KEY="Ek7xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxpOe"
 
 
 #########################################
@@ -44,23 +53,24 @@ SECRET_KEY=
 
 
 #########################################
-##AWS Credentials
+## AWS Credentials(option)
 #########################################
-AWS_ACCESS_KEY=
-AWS_SECRET_KEY=
+export AWS_ACCESS_KEY=AKIxxxxxxxxxxxxxQRQ
+export AWS_SECRET_KEY=UWuxxxxxxxxxxxxxxxxxxxxxxxxxxQCH
 
 
 #########################################
-##MONGODB
+##MONGODB(option)
 #########################################
-MONGODB_URL=
+export MONGODB_URL=
 
 
 ##For test load image from basic auth url
-URL_WITH_BASIC_AUTH=http://username:password@test.xx.xx/ubuntu.tar.gz
+export URL_WITH_BASIC_AUTH=http://xxxx:xxxxxx@test.hyper.sh/ubuntu.tar.gz
 EOF
 
 fi
+
 
 # load util.conf
 source ${WORKDIR}/util.conf
@@ -96,6 +106,15 @@ case $1 in
         -e MONGODB_URL=${MONGODB_URL} \
         -v $(pwd)/../:/go/src/github.com/hyperhq/hypercli \
         hyperhq/hypercli zsh
+    ;;
+  test)
+    mkdir -p ${IMAGE_DIR} 
+    shift
+    if [ $# -ne 0 ];then
+        go test -check.f $@
+    else
+        go test
+    fi
     ;;
   *) show_usage
     ;;


### PR DESCRIPTION
```
[osboxes@osboxes integration-cli (integration-test ✗)]$ ./util.sh test
finish init
INFO: Testing against a remote daemon(tcp://147.75.195.39:6443)
[2017-06-06 09:31:12] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestLoadFromLocalCompressedArchive - 14.537943 sec
[2017-06-06 09:31:33] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestLoadFromLocalDocker - 7.754503 sec
[2017-06-06 09:31:47] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestLoadFromLocalMultipeImage - 1.364237 sec

----------------------------------------------------------------------
FAIL: hyper_cli_load_local_test.go:203: DockerSuite.TestLoadFromLocalMultipeImage

hyper_cli_load_local_test.go:220:
    c.Assert(output, checker.Contains, "Loading multiple images from local is not supported")
... obtained string = "Diffing image with local and remote...\n"
... substring string = "Loading multiple images from local is not supported"

[2017-06-06 09:31:52] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestLoadFromLocalTar - 3.560071 sec
[2017-06-06 09:32:00] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestLoadFromLocalTarDelta - 41.064589 sec
[2017-06-06 09:32:47] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestLoadFromLocalTarPipe - 3.580400 sec
[2017-06-06 09:32:56] github.com/hyperhq/hypercli/integration-cli.(*DockerSuite).TestLoadFromLocalTarSize100MB - 48.842061 sec
OOPS: 6 passed, 1 FAILED
--- FAIL: Test (157.95s)
FAIL
exit status 1
FAIL	github.com/hyperhq/hypercli/integration-cli	160.752s
```