### PR TITLE
check image before pull image in cron and service

### DIFF
--- a/api/client/cron.go
+++ b/api/client/cron.go
@@ -103,8 +103,10 @@ func (cli *DockerCli) CmdCronCreate(args ...string) error {
 		entrypoint = strslice.StrSlice{*flEntrypoint}
 	}
 
-	if err := cli.pullImage(context.Background(), image); err != nil {
-		return err
+	if _, _, err = cli.client.ImageInspectWithRaw(context.Background(), image, false); err != nil {
+		if err := cli.pullImage(context.Background(), image); err != nil {
+			return err
+		}
 	}
 
 	// collect all the environment variables for the container

--- a/api/client/service.go
+++ b/api/client/service.go
@@ -90,8 +90,10 @@ func (cli *DockerCli) CmdServiceCreate(args ...string) error {
 		image      = cmd.Arg(0)
 	)
 
-	if err := cli.pullImage(context.Background(), image); err != nil {
-		return err
+	if _, _, err = cli.client.ImageInspectWithRaw(context.Background(), image, false); err != nil {
+		if err := cli.pullImage(context.Background(), image); err != nil {
+			return err
+		}
 	}
 
 	if len(parsedArgs) > 1 {


### PR DESCRIPTION
```
[lei@h8s-single hypercli]$ hyper/hyper load -i http://image-tarball.s3.amazonaws.com/test/public/ubuntu.tar.gz
Starting to download and load the image archive, please wait...
ubuntu:latest(sha256:2fa927b5cdd31cdec0027ff4f45ef4343795c7a2d19a9af4f32425132a222330) has been loaded.
[lei@h8s-single hypercli]$ hyper/hyper images
REPOSITORY                     TAG                 IMAGE ID            CREATED             SIZE
ubuntu                         latest              2fa927b5cdd3        12 months ago       122 MB
[lei@h8s-single hypercli]$ hyper/hyper cron create  --minute=*/5 --hour=* --name test-cron-job2 ubuntu ping -c 3 8.8.8.8
Cron test-cron-job2 is created.
[lei@h8s-single hypercli]$ hyper/hyper cron ls
Name                Schedule            Image               Command
test-cron-job2      */5 * * * *         ubuntu              ping -c 3 8.8.8.8
```