### PR TITLE
Raplace "path.Base" to "filePath.Base"

### DIFF
--- a/api/client/compose.go
+++ b/api/client/compose.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -515,5 +515,5 @@ func getBaseDir() string {
 	if err != nil {
 		return ""
 	}
-	return path.Base(file)
+	return filepath.Base(file)
 }


### PR DESCRIPTION
In Windows.

When it runs `hyper compose` without "-p" option, current directory name is used as project name.
But in Windows, fullpath like "c:\foo\bar" is given as project name.

`path` always uses slash as path separator.
`filepath` uses appropriate path separator for system.