### PR TITLE
fix test case

### DIFF
--- a/integration-cli/README.md
+++ b/integration-cli/README.md
@@ -31,6 +31,7 @@ Functional test for hyper cli.
 		- [run test in docker container](#run-test-in-docker-container)
 			- [run test via util.sh](#run-test-via-utilsh)
 			- [run test via docker cli](#run-test-via-docker-cli)
+			- [run test via hyper cli](#run-test-via-hyper-cli)
 
 <!-- /TOC -->
 
@@ -332,20 +333,27 @@ $ ./util.sh qa "#222"
 
 #### run test via docker cli
 
-> ACCESS_KEY and SECRET_KEY are required
+Required parameters:
+
+`APIROUTER`: apirouter entrypoint  
+`REGION`: could be us-west-1(zl2), eu-central-1(eu1), RegionOne(packet)  
+`ACCESS_KEY`,`SECRET_KEY`: Hyper credential for test  
+`BRANCH`: hyper cli branch name or PR number  
 
 ```
-//test `master` branch with `zenlayer` apirouter
-$ export ACCESS_KEY="xxxxxxxx"
-$ export SECRET_KEY="xxxxxxxxxxxxxxxxxxxx"
+//test `master` branch of hypercli with `eu-west-1` apirouter
 $ docker run -it --rm \
     -e ACCESS_KEY=${ACCESS_KEY} \
     -e SECRET_KEY=${SECRET_KEY} \
+    -e DOCKER_HOST=tcp://us-west-1.hyper.sh:443 \
+    -e REGION=us-west-1 \
+    -e BRANCH=master \
     hyperhq/hypercli-auto-test:qa go test -check.f TestCli -timeout 180m
-
 
 //test `specified PR`
 $ docker run -it --rm \
+    -e DOCKER_HOST=${APIROUTER} \
+    -e REGION=${REGION} \
     -e ACCESS_KEY=${ACCESS_KEY} \
     -e SECRET_KEY=${SECRET_KEY} \
     -e BRANCH="#221" \
@@ -354,40 +362,47 @@ $ docker run -it --rm \
 
 //test `specified case name`
 $ docker run -it --rm \
+    -e DOCKER_HOST=${APIROUTER} \
+    -e REGION=${REGION} \
     -e ACCESS_KEY="${ACCESS_KEY}" \
     -e SECRET_KEY="${SECRET_KEY}" \
+    -e BRANCH=${BRANCH} \
     hyperhq/hypercli-auto-test:qa go test -check.f 'TestCliInfo|TestCliFip' -timeout 180m
 
 
-//test `specified branch` with `packet` apirouter
+//test with `packet` apirouter
 $ docker run -it --rm \
     -e ACCESS_KEY=${ACCESS_KEY} \
     -e SECRET_KEY=${SECRET_KEY} \
-    -e BRANCH=integration-test \
+    -e BRANCH=${BRANCH} \
     -e DOCKER_HOST=tcp://147.75.x.x:6443 \
+    -e REGION=RegionOne \
     hyperhq/hypercli-auto-test:qa go test -check.f TestCli -timeout 180m
 
 
 //test with http proxy
 $ docker run -it --rm \
+    -e DOCKER_HOST=${APIROUTER} \
+    -e REGION=${REGION} \
     -e ACCESS_KEY=${ACCESS_KEY} \
     -e SECRET_KEY=${SECRET_KEY} \
+    -e BRANCH=${BRANCH} \
     -e http_proxy=${http_proxy} \
     -e https_proxy=${https_proxy} \
     hyperhq/hypercli-auto-test:qa go test -check.f TestCliInfo
     
-//test with region(region name could be us-west-1/eu-central-1)
-$ docker run -it --rm \
-    -e ACCESS_KEY=${ACCESS_KEY} \
-    -e SECRET_KEY=${SECRET_KEY} \
-    -e REGION=${REGION} \
-    -e http_proxy=${http_proxy} \
-    -e https_proxy=${https_proxy} \
-    hyperhq/hypercli-auto-test:qa go test -check.f TestCliInfo
 
 //test basic test case only
 $ docker run -it --rm \
+    -e DOCKER_HOST=${APIROUTER} \
+    -e REGION=${REGION} \
     -e ACCESS_KEY=${ACCESS_KEY} \
     -e SECRET_KEY=${SECRET_KEY} \
+    -e BRANCH=${BRANCH} \
     hyperhq/hypercli-auto-test:qa go test -check.f "TestCli.*Basic" -timeout 180m
+
 ```
+
+#### run test via hyper cli
+
+Just replace `docker` with `hyper` in command line.

--- a/integration-cli/final/cli/hyper_cli_region_test.go
+++ b/integration-cli/final/cli/hyper_cli_region_test.go
@@ -28,23 +28,10 @@ func (s *DockerSuite) TestCliRegionBasic(c *check.C) {
 		anotherRegion = "us-west-1"
 	}
 
-	//delete busybox
-	cmd := exec.Command(dockerBinary, "rmi", "-f", "busybox")
-	runCommandWithOutput(cmd)
-	cmd = exec.Command(dockerBinary, "images", "busybox")
-	out, _, _ := runCommandWithOutput(cmd)
-	c.Assert(out, checker.Not(checker.Contains), "busybox")
-	//delete ubuntu
-	cmd = exec.Command(dockerBinary, "--region", anotherRegion, "rmi", "-f", "ubuntu")
-	runCommandWithOutput(cmd)
-	cmd = exec.Command(dockerBinary, "--region", anotherRegion, "images", "ubuntu")
-	out, _, _ = runCommandWithOutput(cmd)
-	c.Assert(out, checker.Not(checker.Contains), "ubuntu")
-
 	////////////////////////////////////////////
 	//pull image with default region
-	cmd = exec.Command(dockerBinary, "pull", "busybox")
-	out, _, err = runCommandWithOutput(cmd)
+	cmd := exec.Command(dockerBinary, "pull", "busybox")
+	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
 		c.Fatal(err, out)
 	}

--- a/integration-cli/hyper_cli_config_test.go
+++ b/integration-cli/hyper_cli_config_test.go
@@ -9,13 +9,16 @@ import (
 	"github.com/go-check/check"
 	"github.com/hyperhq/hypercli/cliconfig"
 	"github.com/hyperhq/hypercli/pkg/homedir"
+	"os/exec"
 )
 
 func (s *DockerSuite) TestCliConfigAndRewrite(c *check.C) {
 	printTestCaseName()
 	defer printTestDuration(time.Now())
 
-	out, _ := dockerCmd(c, "config", "--default-region" , os.Getenv("REGION"), "--accesskey", "xx", "--secretkey", "xxxx", "tcp://127.0.0.1:6443")
+	cmd := exec.Command(dockerBinary, "config", "--default-region" , os.Getenv("REGION"), "--accesskey", "xx", "--secretkey", "xxxx", "tcp://127.0.0.1:6443")
+	out, _, _, err := runCommandWithStdoutStderr(cmd)
+	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, "WARNING: Your login credentials has been saved in "+homedir.Get()+"/.hyper/config.json")
 
 	configDir := filepath.Join(homedir.Get(), ".hyper")
@@ -24,20 +27,37 @@ func (s *DockerSuite) TestCliConfigAndRewrite(c *check.C) {
 	c.Assert(conf.CloudConfig["tcp://127.0.0.1:6443"].AccessKey, checker.Equals, "xx", check.Commentf("Should get xx, but get %s\n", conf.CloudConfig["tcp://127.0.0.1:6443"].AccessKey))
 	c.Assert(conf.CloudConfig["tcp://127.0.0.1:6443"].SecretKey, checker.Equals, "xxxx", check.Commentf("Should get xxxx, but get %s\n", conf.CloudConfig["tcp://127.0.0.1:6443"].SecretKey))
 
-	out, _ = dockerCmd(c, "config", "--default-region" , os.Getenv("REGION"), "--accesskey", "yy", "--secretkey", "yyyy", "tcp://127.0.0.1:6443")
+
+	cmd = exec.Command(dockerBinary, "config", "--default-region" , os.Getenv("REGION"), "--accesskey", "yy", "--secretkey", "yyyy", "tcp://127.0.0.1:6443")
+	out, _, _, err = runCommandWithStdoutStderr(cmd)
+	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, "WARNING: Your login credentials has been saved in "+homedir.Get()+"/.hyper/config.json")
 
 	conf, err = cliconfig.Load(configDir)
 	c.Assert(err, checker.IsNil)
 	c.Assert(conf.CloudConfig["tcp://127.0.0.1:6443"].AccessKey, checker.Equals, "yy", check.Commentf("Should get yy, but get %s\n", conf.CloudConfig["tcp://127.0.0.1:6443"].AccessKey))
 	c.Assert(conf.CloudConfig["tcp://127.0.0.1:6443"].SecretKey, checker.Equals, "yyyy", check.Commentf("Should get yyyy, but get %s\n", conf.CloudConfig["tcp://127.0.0.1:6443"].SecretKey))
+
+	//patch
+	cmd = exec.Command(dockerBinary, "config", "--default-region" , os.Getenv("REGION"), "--accesskey", os.Getenv("ACCESS_KEY"), "--secretkey", os.Getenv("SECRET_KEY"), os.Getenv("DOCKER_HOST"))
+	out, _, _, err = runCommandWithStdoutStderr(cmd)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, "WARNING: Your login credentials has been saved in "+homedir.Get()+"/.hyper/config.json")
+
+	cmd = exec.Command(dockerBinary, "config", "--default-region" , os.Getenv("REGION"), "--accesskey", os.Getenv("ACCESS_KEY"), "--secretkey", os.Getenv("SECRET_KEY"))
+	out, _, _, err = runCommandWithStdoutStderr(cmd)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, "WARNING: Your login credentials has been saved in "+homedir.Get()+"/.hyper/config.json")
 }
 
 func (s *DockerSuite) TestCliConfigMultiHostBasic(c *check.C) {
 	printTestCaseName()
 	defer printTestDuration(time.Now())
 
-	out, _ := dockerCmd(c, "config", "--default-region" , os.Getenv("REGION"), "--accesskey", "xx", "--secretkey", "xxxx", "tcp://127.0.0.1:6443")
+
+	cmd := exec.Command(dockerBinary, "config", "--default-region" , os.Getenv("REGION"), "--accesskey", "xx", "--secretkey", "xxxx", "tcp://127.0.0.1:6443")
+	out, _, _, err := runCommandWithStdoutStderr(cmd)
+	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, "WARNING: Your login credentials has been saved in "+homedir.Get()+"/.hyper/config.json")
 
 	configDir := filepath.Join(homedir.Get(), ".hyper")
@@ -46,11 +66,24 @@ func (s *DockerSuite) TestCliConfigMultiHostBasic(c *check.C) {
 	c.Assert(conf.CloudConfig["tcp://127.0.0.1:6443"].AccessKey, checker.Equals, "xx", check.Commentf("Should get xx, but get %s\n", conf.CloudConfig["tcp://127.0.0.1:6443"].AccessKey))
 	c.Assert(conf.CloudConfig["tcp://127.0.0.1:6443"].SecretKey, checker.Equals, "xxxx", check.Commentf("Should get xxxx, but get %s\n", conf.CloudConfig["tcp://127.0.0.1:6443"].SecretKey))
 
-	out, _ = dockerCmd(c, "config", "--default-region" , os.Getenv("REGION"), "--accesskey", "yy", "--secretkey", "yyyy", "tcp://127.0.0.1:6444")
+	cmd = exec.Command(dockerBinary, "config", "--default-region" , os.Getenv("REGION"), "--accesskey", "yy", "--secretkey", "yyyy", "tcp://127.0.0.1:6444")
+	out, _, _, err = runCommandWithStdoutStderr(cmd)
+	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, "WARNING: Your login credentials has been saved in "+homedir.Get()+"/.hyper/config.json")
 
 	conf, err = cliconfig.Load(configDir)
 	c.Assert(err, checker.IsNil)
 	c.Assert(conf.CloudConfig["tcp://127.0.0.1:6444"].AccessKey, checker.Equals, "yy", check.Commentf("Should get yy, but get %s\n", conf.CloudConfig["tcp://127.0.0.1:6444"].AccessKey))
 	c.Assert(conf.CloudConfig["tcp://127.0.0.1:6444"].SecretKey, checker.Equals, "yyyy", check.Commentf("Should get yyyy, but get %s\n", conf.CloudConfig["tcp://127.0.0.1:6444"].SecretKey))
+
+	//patch
+	cmd = exec.Command(dockerBinary, "config", "--default-region" , os.Getenv("REGION"), "--accesskey", os.Getenv("ACCESS_KEY"), "--secretkey", os.Getenv("SECRET_KEY"), os.Getenv("DOCKER_HOST"))
+	out, _, _, err = runCommandWithStdoutStderr(cmd)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, "WARNING: Your login credentials has been saved in "+homedir.Get()+"/.hyper/config.json")
+
+	cmd = exec.Command(dockerBinary, "config", "--default-region" , os.Getenv("REGION"), "--accesskey", os.Getenv("ACCESS_KEY"), "--secretkey", os.Getenv("SECRET_KEY"))
+	out, _, _, err = runCommandWithStdoutStderr(cmd)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, "WARNING: Your login credentials has been saved in "+homedir.Get()+"/.hyper/config.json")
 }

--- a/integration-cli/util.sh
+++ b/integration-cli/util.sh
@@ -7,12 +7,12 @@ function show_usage() {
     cat <<EOF
 Usage: ./util.sh <action>
 <action>:
-    build-dev    # build docker image 'hyperhq/hypercl' from Dockerfile.dev
-    build-qa     # build docker image 'hyperhq/hypercl' from Dockerfile.qa
-    make         # make hyper cli in container
-    enter        # enter container from hyperhq/hhypercli-auto-test:dev
-    qa <branch>  # run test case in hyperhq/hhypercli-auto-test:qa, default branch is 'master'
-    test         # test on host
+    build-dev          # build docker image 'hyperhq/hypercl' from Dockerfile.dev
+    build-qa           # build docker image 'hyperhq/hypercl' from Dockerfile.qa
+    make               # make hyper cli in container
+    enter-dev          # enter container from hyperhq/hhypercli-auto-test:dev
+    enter-qa <branch>  # enter container from hyperhq/hhypercli-auto-test:qa, default branch is 'master'
+    test               # test on host
 EOF
 }
 
@@ -68,12 +68,12 @@ case $1 in
         -v $(pwd)/../:/go/src/github.com/hyperhq/hypercli \
         ${IMAGE_NAME}:dev ./build.sh
     ;;
-  enter)
+  enter-dev)
     docker run -it --rm \
         -e DOCKER_HOST=${HYPER_HOST} \
+        -e REGION=${REGION} \
         -e ACCESS_KEY=${ACCESS_KEY} \
         -e SECRET_KEY=${SECRET_KEY} \
-        -e REGION=${REGION} \
         -e AWS_ACCESS_KEY=${AWS_ACCESS_KEY} \
         -e AWS_SECRET_KEY=${AWS_SECRET_KEY} \
         -e URL_WITH_BASIC_AUTH=${URL_WITH_BASIC_AUTH} \
@@ -84,7 +84,7 @@ case $1 in
         -v $(pwd)/../:/go/src/github.com/hyperhq/hypercli \
         ${IMAGE_NAME}:dev zsh
     ;;
-  qa)
+  enter-qa)
     BRANCH=$2
     if [ "$BRANCH" == "" ];then
       BRANCH="master"
@@ -92,14 +92,16 @@ case $1 in
     docker run -it --rm \
         -e http_proxy=${http_proxy} \
         -e https_proxy=${https_proxy} \
-        -e BRANCH=${BRANCH} \
         -e DOCKER_HOST=${HYPER_HOST} \
+        -e REGION=${REGION} \
+        -e BRANCH=${BRANCH} \
         -e ACCESS_KEY=${ACCESS_KEY} \
         -e SECRET_KEY=${SECRET_KEY} \
         -e DOCKERHUB_EMAIL=${DOCKERHUB_EMAIL} \
         -e DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME} \
         -e DOCKERHUB_PASSWD=${DOCKERHUB_PASSWD} \
-        ${IMAGE_NAME}:qa go test -check.f TestCli -timeout 180m
+        ${IMAGE_NAME}:qa /bin/bash
+#        ${IMAGE_NAME}:qa go test -check.f TestCli -timeout 180m
     ;;
   test)
     export DOCKER_HOST=${HYPER_HOST}


### PR DESCRIPTION
adjust integration test for cron job

```
#zl2 container test eu1
HYPER_ACCESS_KEY=xxx
HYPER_SECRET_KEY=xxx
APIROUTER="tcp://eu-central-1.hyper.sh:443"
REGION="eu-central-1"
BRANCH="#236"
hyper --region us-west-1 \
    run -it --rm \
    -e ACCESS_KEY="${HYPER_ACCESS_KEY}" \
    -e SECRET_KEY="${HYPER_SECRET_KEY}" \
    -e BRANCH=$BRANCH \
    -e REGION="$REGION" \
    -e DOCKER_HOST="${APIROUTER}" \
    hyperhq/hypercli-auto-test:qa go test -check.f "TestCli.*Basic" -timeout 90m

#eu1 container test zl2
HYPER_ACCESS_KEY=xxx
HYPER_SECRET_KEY=xxx
APIROUTER="tcp://us-west-1.hyper.sh:443"
REGION="us-west-1"
BRANCH="#236"
hyper --region eu-west-1 \
    run -it --rm \
    -e ACCESS_KEY="${HYPER_ACCESS_KEY}" \
    -e SECRET_KEY="${HYPER_SECRET_KEY}" \
    -e BRANCH=$BRANCH \
    -e REGION="$REGION" \
    -e DOCKER_HOST="${APIROUTER}" \
    hyperhq/hypercli-auto-test:qa go test -check.f "TestCli.*Basic" -timeout 90m

# zl2 container test packet
HYPER_ACCESS_KEY_PKT=yyy
HYPER_SECRET_KEY_PKT=yyy
APIROUTER="tcp://147.75.x.x:6443"
BRANCH="#236"
REGION="RegionOne"
hyper  --region us-west-1 \
    run -it --rm \
    -e ACCESS_KEY="${HYPER_ACCESS_KEY_PKT}" \
    -e SECRET_KEY="${HYPER_SECRET_KEY_PKT}" \
    -e BRANCH=$BRANCH \
    -e REGION="$REGION" \
    -e DOCKER_HOST="${APIROUTER}" \
    hyperhq/hypercli-auto-test:qa go test -check.f "TestCli.*Basic" -timeout 90m
```

